### PR TITLE
Added definition of min() for ESP8266

### DIFF
--- a/src/util/inv_mpu.c
+++ b/src/util/inv_mpu.c
@@ -28,6 +28,9 @@
 #define min(a,b) ((a)<(b)?(a):(b))
 #endif
 
+#ifdef ESP8266
+#define min(a,b) ((a)<(b)?(a):(b))
+#endif
 
 /* The following functions must be defined for this platform:
  * i2c_write(unsigned char slave_addr, unsigned char reg_addr,


### PR DESCRIPTION
Turns out this definition needs to work for ESP8266 as well in order to compile. 